### PR TITLE
Add localizeNumber to number.utils

### DIFF
--- a/src/utils/number.utils.ts
+++ b/src/utils/number.utils.ts
@@ -140,7 +140,7 @@ export function isNumberOdd(number: number): boolean {
 }
 
 /**
- * Localize a number into a en-US formatted string.
+ * Localize a number into a en-US formatted string with up to 3 decimals.
  */
 export function localizeNumber(number: number): string {
   return number.toLocaleString('en-US')

--- a/src/utils/number.utils.ts
+++ b/src/utils/number.utils.ts
@@ -138,3 +138,10 @@ export function isNumberMultipleOf(number: number, of: number): boolean {
 export function isNumberOdd(number: number): boolean {
   return Math.abs(number % 2) == 1
 }
+
+/**
+ * Localize a number into a en-US formatted string.
+ */
+export function localizeNumber(number: number): string {
+  return number.toLocaleString('en-US')
+}

--- a/tests/utils/number.utils.test.ts
+++ b/tests/utils/number.utils.test.ts
@@ -115,8 +115,8 @@ describe('NumberUtils', () => {
     expect(isNumberMultipleOf(6, 2)).toBeTruthy()
   })
 
-  it('formats number as an en-US formatted string', () => {
-    expect(localizeNumber(0.385)).toBe('0.385')
+  it('formats number as an en-US formatted string with up to 3 decimals', () => {
+    expect(localizeNumber(0.38521)).toBe('0.385')
     expect(localizeNumber(1)).toBe('1')
     expect(localizeNumber(1000)).toBe('1,000')
     expect(localizeNumber(10999)).toBe('10,999')

--- a/tests/utils/number.utils.test.ts
+++ b/tests/utils/number.utils.test.ts
@@ -9,6 +9,7 @@ import {
   isNumberEven,
   isNumberMultipleOf,
   isNumberOdd,
+  localizeNumber,
   parseBigInt,
   parseNumber,
   toFixedNumber
@@ -112,5 +113,13 @@ describe('NumberUtils', () => {
     expect(isNumberMultipleOf(2, 3)).toBeFalsy()
     expect(isNumberMultipleOf(4, 2)).toBeTruthy()
     expect(isNumberMultipleOf(6, 2)).toBeTruthy()
+  })
+
+  it('formats number as an en-US formatted string', () => {
+    expect(localizeNumber(0.385)).toBe('0.385')
+    expect(localizeNumber(1)).toBe('1')
+    expect(localizeNumber(1000)).toBe('1,000')
+    expect(localizeNumber(10999)).toBe('10,999')
+    expect(localizeNumber(193801284.283)).toBe('193,801,284.283')
   })
 })


### PR DESCRIPTION
Added the localizeNumber method that creates en-US-formatted string with up to 3 decimals (the default value).